### PR TITLE
Fix failing tests

### DIFF
--- a/test/open_exchange_rates_bank_test.rb
+++ b/test/open_exchange_rates_bank_test.rb
@@ -51,6 +51,7 @@ describe Money::Bank::OpenExchangeRatesBank do
         :separator => ".",
         :delimiter => ","
       }
+      Money::Currency::STRINGIFIED_KEYS = Money::Currency::TABLE.keys.map{|k| k.to_s.downcase }
       @bank.add_rate("USD", "BTC", 1 / 13.7603)
       @bank.add_rate("BTC", "USD", 13.7603)
       @bank.exchange(100, "BTC", "USD").cents.must_equal 138


### PR DESCRIPTION
Some minor fixes to get the tests to pass. 2 tests fail because of incorrect rounding and 1 throws an exception because Money doesn't load a newly added currency correctly. Using ruby 1.8.7-p358

Includes a minor hack for getting Money (v4.0.2) to load a new currency correctly.
