### PR TITLE
Make money-open-exchange-rates more defensive in writing its cache file & working without rates

### DIFF
--- a/lib/money/bank/open_exchange_rates_bank.rb
+++ b/lib/money/bank/open_exchange_rates_bank.rb
@@ -27,10 +27,15 @@ class Money
         open(OER_URL).read
       end
 
+      def has_valid_rates?(text)
+        text && text.size > 0 && Yajl::Parser.parse(text).has_key?('rates')
+      end
+
+
       def save_rates
         raise InvalidCache unless cache
         new_text = read_from_url
-        if new_text && new_text.size != 0
+        if has_valid_rates?(new_text)
           open(cache, 'w') do |f|
             f.write(new_text)
           end

--- a/test/open_exchange_rates_bank_test.rb
+++ b/test/open_exchange_rates_bank_test.rb
@@ -148,6 +148,13 @@ describe Money::Bank::OpenExchangeRatesBank do
       File.open(@temp_cache_path).read.size.must_equal initial_size
     end
 
+    it "should not break an existing file if save returns json without rates" do
+      initial_size = File.read(@temp_cache_path).size
+      stub(@bank).read_from_url {{:error => "An error"}.to_json}
+      @bank.save_rates
+      File.open(@temp_cache_path).read.size.must_equal initial_size
+    end
+
     after do
       File.delete @temp_cache_path
     end


### PR DESCRIPTION
We ran into an issue where a timeout from the exchange rates API resulted in the cache file being overwritten as blank, causing the gem to cease functioning.  These changesets update the gem to not over-write the cache file if a bad response or no response comes back from the API, as well as allowing the gem to continue functioning for the most basic case (exchanging a currency into itself; frequent use case for us given a large percentage of our prices are in USD, and most customers are seeing USD).
