### PR TITLE
Allow Proc for cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.lock
 *.gem
+*.swp
+TEST_APP_ID

--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,20 @@ moe.update_rates
 Money.default_bank = moe
 ```
 
+You can also provide a Proc as a cache to provide your own caching mechanism
+perhaps with Redis or just a thread safe `Hash` (global). For example:
+
+```ruby
+moe.cache = Proc.new do |v|
+  key = 'money:exchange_rates']
+  if v
+    Thread.current[key] = v
+  else
+    Thread.current[key]
+  end
+end
+```
+
 ## Tests
 
 As of the end of August 2012 all requests to the Open Exchange Rates API must have a valid app_id. You can place your own key at the top of test/open_exchange_rates_bank_test.rb in TEST_APP_ID and then run:

--- a/money-open-exchange-rates.gemspec
+++ b/money-open-exchange-rates.gemspec
@@ -1,9 +1,9 @@
 Gem::Specification.new do |s|
   s.name = "money-open-exchange-rates"
-  s.version = "0.0.7"
+  s.version = "0.1.0"
   s.date = Time.now.utc.strftime("%Y-%m-%d")
   s.homepage = "http://github.com/spk/#{s.name}"
-  s.authors = "Laurent Arnoud"
+  s.authors = ["Laurent Arnoud", "Sam Lown"]
   s.email = "laurent@spkdev.net"
   s.description = "A gem that calculates the exchange rate using published rates from open-exchange-rates. Compatible with the money gem."
   s.summary = "A gem that calculates the exchange rate using published rates from open-exchange-rates."
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir.glob("test/*_test.rb")
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}
-  s.add_dependency "yajl-ruby", ">=0.8.3"
+  s.add_dependency "multi_json", "~> 1.0"
   s.add_dependency "money", ">=3.7.1"
   s.add_development_dependency "minitest", ">=2.0"
   s.add_development_dependency "rr", ">=1.0.4"


### PR DESCRIPTION
This version, aside from including p7r's changes for the now required app_id, allows a Proc block to be provided as a cache instead of a filename. This allows much greater flexibility including using more advanced storage mechanisms like a database or Redis.
