### PR TITLE
Add the ability to expire rates after a fixed amount of time

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,6 +12,11 @@ moe.cache = 'path/to/file/cache'
 moe.app_id = 'your app id from https://openexchangerates.org/signup'
 moe.update_rates
 
+# (optional)
+# set the seconds after than the current rates are automatically expired
+# by default, they never expire
+moe.ttl_in_seconds = 86400
+
 Money.default_bank = moe
 ```
 

--- a/money-open-exchange-rates.gemspec
+++ b/money-open-exchange-rates.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", ">=2.0"
   s.add_development_dependency "rr", ">=1.0.4"
   s.add_development_dependency "rake"
+  s.add_development_dependency "timecop"
   s.add_dependency "json", ">= 1.7"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'minitest/autorun'
 require 'rr'
 require 'money/bank/open_exchange_rates_bank'
 require 'monetize/core_extensions'
+require 'timecop'
 Money.silence_core_extensions_deprecations = true
 
 TEST_APP_ID_PATH = File.join(File.dirname(__FILE__), '..', 'TEST_APP_ID')


### PR DESCRIPTION
Having the update_rates in a rails initializer it'd require a server process restart in order to update the rates on the current process or a manual call before doing the exchange conversion. This way it automatically do it after a given time (the default is to not expire them)
