### PR TITLE
Removing false positive in TTL test

### DIFF
--- a/test/open_exchange_rates_bank_test.rb
+++ b/test/open_exchange_rates_bank_test.rb
@@ -254,7 +254,6 @@ describe Money::Bank::OpenExchangeRatesBank do
       end
 
       it 'should update the rates' do
-        subject.update_rates
         subject.get_rate('USD', 'EUR').wont_equal @usd_eur_rate
       end
 


### PR DESCRIPTION
TTL expiration was never actually being tested.

Previously if you remove the before block, the test will still pass.