### PR TITLE
Added the secure_connection option to enable HTTPS connections to OER

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,6 +16,10 @@ moe.update_rates
 # set the seconds after than the current rates are automatically expired
 # by default, they never expire
 moe.ttl_in_seconds = 86400
+# (optional)
+# use https to fetch rates from Open Exchange Rates
+# disabled by default to support free-tier users
+moe.secure_connection = true
 # Store in cache
 moe.save_rates
 
@@ -63,6 +67,7 @@ Dmitry Dedov (2)
 chatgris (2)
 Sam Lown (1)
 Fabio Cantoni (1)
+shpupti (1)
 
 ## License
 

--- a/lib/money/bank/open_exchange_rates_bank.rb
+++ b/lib/money/bank/open_exchange_rates_bank.rb
@@ -54,6 +54,15 @@ class Money
         end
       end
 
+      def source_url
+        raise NoAppId if app_id.nil? || app_id.empty?
+        oer_url = OER_URL
+        if secure_connection
+          oer_url = SECURE_OER_URL
+        end
+        "#{oer_url}?app_id=#{app_id}"
+      end
+
       protected
 
       # Store the provided text data by calling the proc method provided
@@ -76,14 +85,7 @@ class Money
         end
       end
 
-      def source_url
-        raise NoAppId if app_id.nil? || app_id.empty?
-        oer_url = OER_URL
-        if secure_connection
-          oer_url = SECURE_OER_URL
-        end
-        "#{oer_url}?app_id=#{app_id}"
-      end
+
 
       def read_from_url
         open(source_url).read

--- a/lib/money/bank/open_exchange_rates_bank.rb
+++ b/lib/money/bank/open_exchange_rates_bank.rb
@@ -12,8 +12,9 @@ class Money
     class OpenExchangeRatesBank < Money::Bank::VariableExchange
 
       OER_URL = 'http://openexchangerates.org/latest.json'
+      SECURE_OER_URL = OER_URL.gsub(/http:/, "https:")
 
-      attr_accessor :cache, :app_id
+      attr_accessor :cache, :app_id, :secure_connection
       attr_reader :doc, :oer_rates, :rates_expiration, :ttl_in_seconds
 
       def ttl_in_seconds=(value)
@@ -77,7 +78,11 @@ class Money
 
       def source_url
         raise NoAppId if app_id.nil? || app_id.empty?
-        "#{OER_URL}?app_id=#{app_id}"
+        oer_url = OER_URL
+        if secure_connection
+          oer_url = SECURE_OER_URL
+        end
+        "#{oer_url}?app_id=#{app_id}"
       end
 
       def read_from_url

--- a/test/open_exchange_rates_bank_test.rb
+++ b/test/open_exchange_rates_bank_test.rb
@@ -142,6 +142,26 @@ describe Money::Bank::OpenExchangeRatesBank do
     end
   end
 
+  describe 'secure_connection' do
+    it "should use the default non-secure http url if secure_connection isn't set" do
+      subject.secure_connection = nil
+      subject.app_id = TEST_APP_ID
+      subject.source_url.must_equal "#{Money::Bank::OpenExchangeRatesBank::OER_URL}?app_id=#{TEST_APP_ID}"
+    end
+
+    it "should use the default non-secure http url if secure_connection is set to false" do
+      subject.secure_connection = false
+      subject.app_id = TEST_APP_ID
+      subject.source_url.must_equal "#{Money::Bank::OpenExchangeRatesBank::OER_URL}?app_id=#{TEST_APP_ID}"
+    end
+
+    it "should use the secure https url if secure_connection is set to true" do
+      subject.secure_connection = true
+      subject.app_id = TEST_APP_ID
+      subject.source_url.must_equal "#{Money::Bank::OpenExchangeRatesBank::SECURE_OER_URL}?app_id=#{TEST_APP_ID}"
+    end
+  end
+
   describe 'no valid file for cache' do
     before do
       subject.cache = "space_dir#{rand(999999999)}/out_space_file.json"


### PR DESCRIPTION
Decided to the leave the default as non-secure to prevent breaking changes (for free-tier users).