### PR TITLE
Fix rubocop to 0.41.2 for Ruby 1.9 support

### DIFF
--- a/money-open-exchange-rates.gemspec
+++ b/money-open-exchange-rates.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'timecop', '~> 0.8'
   s.add_development_dependency 'rr', '~> 1.1'
   s.add_development_dependency 'webmock', '~> 1'
-  s.add_development_dependency 'rubocop', '~> 0.41'
+  s.add_development_dependency 'rubocop', '~> 0.41.2'
 end


### PR DESCRIPTION
Fix CI build for ruby 1.9
