### PR TITLE
Fix incorrect url concatenation

### DIFF
--- a/lib/money/bank/open_exchange_rates_bank.rb
+++ b/lib/money/bank/open_exchange_rates_bank.rb
@@ -22,7 +22,7 @@ class Money
       BASE_URL = 'http://openexchangerates.org/api/'.freeze
       # OpenExchangeRates urls
       OER_URL = URI.join(BASE_URL, 'latest.json')
-      OER_HISTORICAL_URL = URI.join(BASE_URL, '/historical/')
+      OER_HISTORICAL_URL = URI.join(BASE_URL, 'historical/')
       # OpenExchangeRates secure url
       SECURE_OER_URL = OER_URL.clone
       SECURE_OER_URL.scheme = 'https'

--- a/lib/money/bank/open_exchange_rates_bank.rb
+++ b/lib/money/bank/open_exchange_rates_bank.rb
@@ -19,7 +19,7 @@ class Money
     # OpenExchangeRatesBank base class
     class OpenExchangeRatesBank < Money::Bank::VariableExchange
       VERSION = ::OpenExchangeRatesBank::VERSION
-      BASE_URL = 'http://openexchangerates.org/api'.freeze
+      BASE_URL = 'http://openexchangerates.org/api/'.freeze
       # OpenExchangeRates urls
       OER_URL = URI.join(BASE_URL, 'latest.json')
       OER_HISTORICAL_URL = URI.join(BASE_URL, '/historical/')


### PR DESCRIPTION
`URI.join` behaves differently to `File.join`, in that if there is no trailing 
`/` on a string, the url path will be replaced.

Also, if the string to be concatenated starts with a `/`, it will also replace 
the url path, even if the url ends with a `/`.

This causes redirection forbidden exceptions with `open-uri`, and this pull 
request resolves those.