### PR TITLE
Use bundled JSON instead of gem

### DIFF
--- a/money-open-exchange-rates.gemspec
+++ b/money-open-exchange-rates.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.rubygems_version = '1.3.7'
   s.add_dependency 'money', '~> 6.7'
   s.add_dependency 'monetize', '~> 1.4'
-  s.add_dependency 'json', '~> 1.8'
   s.add_development_dependency 'rake', '~> 11'
   s.add_development_dependency 'minitest', '~> 5'
   s.add_development_dependency 'timecop', '~> 0.8'


### PR DESCRIPTION
JSON has been included in Ruby since 1.9.2. As Ruby 1.9.3 or newer is required in gemspec, the JSON gem dependency can be dropped.

JSON 1.8.3 (which is the newest matching the current requirement) does not compile in Ruby 2.4: https://github.com/flori/json/issues/303