### PR TITLE
 Add support for Alternative Rates ('show_alternative')

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ oxr.date = '2015-01-01'
 # OpenExchangeRates only allows USD as base currency
 # for the free plan users.
 oxr.source = 'USD'
+# (optional)
+# Extend returned values with alternative, black market and digital currency
+# rates. By default, false is used
+# see: https://docs.openexchangerates.org/docs/alternative-currencies
+oxr.show_alternative = true
 
 # Store in cache
 # If you are using unicorn-worker-killer gem or on Heroku like platform,

--- a/lib/money/bank/open_exchange_rates_bank.rb
+++ b/lib/money/bank/open_exchange_rates_bank.rb
@@ -88,6 +88,15 @@ class Money
       # @return [Integer] Setted time to live in seconds
       attr_reader :ttl_in_seconds
 
+      # Set support for the black market and alternative digital currencies
+      # see https://docs.openexchangerates.org/docs/alternative-currencies
+      # @example
+      #   oxr.show_alternative = true
+      #
+      # @param [Boolean] if true show alternative
+      # @return [Boolean] Setted show alternative
+      attr_writer :show_alternative
+
       # Set the seconds after than the current rates are automatically expired
       # by default, they never expire.
       #
@@ -177,19 +186,11 @@ class Money
         refresh_rates_expiration
       end
 
-      # Set unofficial support for black market and alternative digital currencies
-      #
-      # @param [Boolean] if true show alternative
-      # @return [Boolean] Setted show alternative
-      def show_alternative=(value)
-        @show_alternative = value
-      end
-
       # Get show alternative
       #
       # @return [Boolean] if true show alternative
       def show_alternative
-        @show_alternative || false
+        @show_alternative ||= false
       end
 
       # Source url of openexchangerates
@@ -198,9 +199,11 @@ class Money
       # @return [String] URL
       def source_url
         if source == OE_SOURCE
-          "#{oer_url}?app_id=#{app_id}&show_alternative=#{show_alternative}"
+          "#{oer_url}?app_id=#{app_id}" \
+          "&show_alternative=#{show_alternative}"
         else
-          "#{oer_url}?app_id=#{app_id}&base=#{source}&show_alternative=#{show_alternative}"
+          "#{oer_url}?app_id=#{app_id}&base=#{source}" \
+          "&show_alternative=#{show_alternative}"
         end
       end
 

--- a/lib/money/bank/open_exchange_rates_bank.rb
+++ b/lib/money/bank/open_exchange_rates_bank.rb
@@ -177,15 +177,30 @@ class Money
         refresh_rates_expiration
       end
 
+      # Set unofficial support for black market and alternative digital currencies
+      #
+      # @param [Boolean] if true show alternative
+      # @return [Boolean] Setted show alternative
+      def show_alternative=(value)
+        @show_alternative = value
+      end
+
+      # Get show alternative
+      #
+      # @return [Boolean] if true show alternative
+      def show_alternative
+        @show_alternative || false
+      end
+
       # Source url of openexchangerates
       # defined with app_id and secure_connection
       #
       # @return [String] URL
       def source_url
         if source == OE_SOURCE
-          "#{oer_url}?app_id=#{app_id}"
+          "#{oer_url}?app_id=#{app_id}&show_alternative=#{show_alternative}"
         else
-          "#{oer_url}?app_id=#{app_id}&base=#{source}"
+          "#{oer_url}?app_id=#{app_id}&base=#{source}&show_alternative=#{show_alternative}"
         end
       end
 

--- a/test/open_exchange_rates_bank_test.rb
+++ b/test/open_exchange_rates_bank_test.rb
@@ -166,11 +166,11 @@ describe Money::Bank::OpenExchangeRatesBank do
       end
 
       def historical_url
-        "#{oer_historical_url}#{subject.date}.json?app_id=#{TEST_APP_ID}"
+        "#{oer_historical_url}#{subject.date}.json?app_id=#{TEST_APP_ID}&show_alternative=false"
       end
 
       def historical_secure_url
-        "#{oer_historical_secure_url}#{subject.date}.json?app_id=#{TEST_APP_ID}"
+        "#{oer_historical_secure_url}#{subject.date}.json?app_id=#{TEST_APP_ID}&show_alternative=false"
       end
 
       it 'should use the non-secure http url if secure_connection is nil' do
@@ -197,11 +197,11 @@ describe Money::Bank::OpenExchangeRatesBank do
 
     describe 'latest' do
       def source_url
-        "#{oer_url}?app_id=#{TEST_APP_ID}"
+        "#{oer_url}?app_id=#{TEST_APP_ID}&show_alternative=false"
       end
 
       def source_secure_url
-        "#{oer_secure_url}?app_id=#{TEST_APP_ID}"
+        "#{oer_secure_url}?app_id=#{TEST_APP_ID}&show_alternative=false"
       end
 
       it 'should use the non-secure http url if secure_connection is nil' do
@@ -382,6 +382,37 @@ describe Money::Bank::OpenExchangeRatesBank do
     it 'should use USD when given unknown currency' do
       subject.source = 'invalid'
       subject.source.must_equal 'USD'
+    end
+  end
+
+  describe 'show alternative' do
+
+    describe 'when no value given' do
+      before do
+        subject.show_alternative = nil
+      end
+
+      it 'should return the default value' do
+        subject.show_alternative.must_equal false
+      end
+
+      it 'should include show_alternative param as false' do
+        subject.source_url.must_include "show_alternative=false"
+      end
+    end
+
+    describe 'when value is given' do
+      before do
+        subject.show_alternative = true
+      end
+
+      it 'should return the value' do
+        subject.show_alternative.must_equal true
+      end
+
+      it 'should include show_alternative param as true' do
+        subject.source_url.must_include "show_alternative=true"
+      end
     end
   end
 end

--- a/test/open_exchange_rates_bank_test.rb
+++ b/test/open_exchange_rates_bank_test.rb
@@ -166,11 +166,13 @@ describe Money::Bank::OpenExchangeRatesBank do
       end
 
       def historical_url
-        "#{oer_historical_url}#{subject.date}.json?app_id=#{TEST_APP_ID}&show_alternative=false"
+        "#{oer_historical_url}#{subject.date}.json?" \
+        "app_id=#{TEST_APP_ID}&show_alternative=false"
       end
 
       def historical_secure_url
-        "#{oer_historical_secure_url}#{subject.date}.json?app_id=#{TEST_APP_ID}&show_alternative=false"
+        "#{oer_historical_secure_url}#{subject.date}.json?" \
+        "app_id=#{TEST_APP_ID}&show_alternative=false"
       end
 
       it 'should use the non-secure http url if secure_connection is nil' do
@@ -386,7 +388,6 @@ describe Money::Bank::OpenExchangeRatesBank do
   end
 
   describe 'show alternative' do
-
     describe 'when no value given' do
       before do
         subject.show_alternative = nil
@@ -397,7 +398,7 @@ describe Money::Bank::OpenExchangeRatesBank do
       end
 
       it 'should include show_alternative param as false' do
-        subject.source_url.must_include "show_alternative=false"
+        subject.source_url.must_include 'show_alternative=false'
       end
     end
 
@@ -411,7 +412,7 @@ describe Money::Bank::OpenExchangeRatesBank do
       end
 
       it 'should include show_alternative param as true' do
-        subject.source_url.must_include "show_alternative=true"
+        subject.source_url.must_include 'show_alternative=true'
       end
     end
   end


### PR DESCRIPTION
Add support for alternative rates as described here: https://docs.openexchangerates.org/docs/alternative-currencies.