### PR TITLE
Fix issue with Float casting for BigDecimal

### DIFF
--- a/lib/money/bank/open_exchange_rates_bank.rb
+++ b/lib/money/bank/open_exchange_rates_bank.rb
@@ -326,7 +326,7 @@ class Money
         from_base_rate = get_rate_or_calc_inverse(source, from_currency, opts)
         to_base_rate   = get_rate_or_calc_inverse(source, to_currency, opts)
         if to_base_rate && from_base_rate
-          rate = BigDecimal(to_base_rate) / from_base_rate
+          rate = BigDecimal(to_base_rate.to_s) / from_base_rate
           add_rate(from_currency, to_currency, rate)
           return rate
         end

--- a/lib/open_exchange_rates_bank/version.rb
+++ b/lib/open_exchange_rates_bank/version.rb
@@ -2,5 +2,5 @@
 
 # Module for version constant
 module OpenExchangeRatesBank
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
 end

--- a/test/open_exchange_rates_bank_test.rb
+++ b/test/open_exchange_rates_bank_test.rb
@@ -63,6 +63,11 @@ describe Money::Bank::OpenExchangeRatesBank do
         subject.exchange_with(money, 'BMD').must_equal Money.new(50, 'BMD')
       end
 
+      it 'should be able to handle non integer rates' do
+        money = Money.new(100, 'BBD')
+        subject.exchange_with(money, 'TJS').must_equal Money.new(250, 'TJS')
+      end
+
       it "should raise if it can't find an exchange rate" do
         money = Money.new(0, 'USD')
         proc { subject.exchange_with(money, 'SSP') }


### PR DESCRIPTION
Fixes https://github.com/spk/money-open-exchange-rates/issues/45.

When the rate is a Float, we are trying to cast it to BigDecimal but BigDecimal is not capable of doing it so we need to cast it to String first.