### PR TITLE
Use `monetize` as a development dependency only

### DIFF
--- a/money-open-exchange-rates.gemspec
+++ b/money-open-exchange-rates.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0'
   s.rubygems_version = '1.3.7'
   s.add_dependency 'money', '~> 6.6'
-  s.add_dependency 'monetize', '>= 1.3.1', '< 2'
+  s.add_development_dependency 'monetize', '>= 1.3.1', '< 2'
   s.add_development_dependency 'rake', '~> 12'
   s.add_development_dependency 'minitest', '~> 5'
   s.add_development_dependency 'timecop', '~> 0.8'


### PR DESCRIPTION
Hi all 👋 

Thank you for useful library!

I just noticed unnecessary extra dependencies in the my project after I started to use this gem - it was `monetize` gem and it does nothing useful into this gem, neither into my project. So I assume it would be better to use this gem as a development/test dependency only.

I have checked all the test w/o `monetize` as well. It is used in two places:

https://github.com/spk/money-open-exchange-rates/blob/4959d1f8d7de52f3b97dd3f66eb8f8deabfb2ab7/test/open_exchange_rates_bank_test.rb#L107

https://github.com/spk/money-open-exchange-rates/blob/4959d1f8d7de52f3b97dd3f66eb8f8deabfb2ab7/test/open_exchange_rates_bank_test.rb#L126

It's quite simple to use `Money.from_amount` here and do not have an extra dependency with a dozen of monkey-patches 🙈 

What do you think, guys?