### PR TITLE
Fix unclosed file descriptor after read_from_cache

### DIFF
--- a/lib/money/bank/open_exchange_rates_bank.rb
+++ b/lib/money/bank/open_exchange_rates_bank.rb
@@ -324,7 +324,7 @@ class Money
         result = if cache.is_a?(Proc)
                    cache.call(nil)
                  elsif File.exist?(cache.to_s)
-                   File.open(cache).read
+                   File.read(cache)
                  end
         result if valid_rates?(result)
       end


### PR DESCRIPTION
Subj, `IO.read` ensures the file is closed before returning, while `File.open(...).read` leave unclosed descriptor.