### PR TITLE
Raise AccessRestricted error when account is restricted by OER

### DIFF
--- a/lib/money/bank/open_exchange_rates_bank.rb
+++ b/lib/money/bank/open_exchange_rates_bank.rb
@@ -17,6 +17,9 @@ class Money
     # APP_ID not set error
     class NoAppId < StandardError; end
 
+    # Access restricted (e.g. usage/request limit exceeded for account)
+    class AccessRestricted < StandardError; end
+
     # OpenExchangeRatesBank base class
     class OpenExchangeRatesBank < Money::Bank::VariableExchange
       VERSION = ::OpenExchangeRatesBank::VERSION
@@ -371,6 +374,10 @@ class Money
       # @return [Hash] key is country code (ISO 3166-1 alpha-3) value Float
       def exchange_rates
         doc = JSON.parse(read_from_cache || read_from_url)
+        if doc['error'] && doc['message'] == 'access_restricted'
+          raise AccessRestricted
+        end
+
         self.rates_timestamp = doc[TIMESTAMP_KEY]
         @oer_rates = doc[RATES_KEY]
       end

--- a/test/data/access_restricted_error.json
+++ b/test/data/access_restricted_error.json
@@ -1,0 +1,6 @@
+{
+  "error": true,
+  "status": 429,
+  "message": "access_restricted",
+  "description": "Access restricted until 2050-01-01 (reason: too_many_requests). If there has been a mistake, please contact support@openexchangerates.org."
+}

--- a/test/open_exchange_rates_bank_test.rb
+++ b/test/open_exchange_rates_bank_test.rb
@@ -25,6 +25,9 @@ describe Money::Bank::OpenExchangeRatesBank do
   let(:oer_historical_path) do
     data_file('2015-01-01.json')
   end
+  let(:oer_access_restricted_error_path) do
+    data_file('access_restricted_error.json')
+  end
 
   describe 'exchange' do
     before do
@@ -94,6 +97,13 @@ describe Money::Bank::OpenExchangeRatesBank do
       subject.app_id = TEST_APP_ID
       subject.cache = oer_latest_path
       subject.update_rates
+    end
+
+    it 'should raise AccessRestricted error when restricted by oer' do
+      subject.cache = nil
+      filepath = oer_access_restricted_error_path
+      subject.stubs(:api_response).returns File.read(filepath)
+      (proc { subject.update_rates }).must_raise Money::Bank::AccessRestricted
     end
 
     it 'should update itself with exchange rates from OpenExchangeRates' do

--- a/test/open_exchange_rates_bank_test.rb
+++ b/test/open_exchange_rates_bank_test.rb
@@ -103,7 +103,7 @@ describe Money::Bank::OpenExchangeRatesBank do
       subject.cache = nil
       filepath = oer_access_restricted_error_path
       subject.stubs(:api_response).returns File.read(filepath)
-      (proc { subject.update_rates }).must_raise Money::Bank::AccessRestricted
+      _(proc { subject.update_rates }).must_raise Money::Bank::AccessRestricted
     end
 
     it 'should update itself with exchange rates from OpenExchangeRates' do


### PR DESCRIPTION
This adds base support for handling the errors [documented by openexchangerates.org](https://docs.openexchangerates.org/reference/errors). This PR intentionally only adds support for the `"access_restricted"` error at this point. This leaves open the discussion of adding all or a subset of all the errors that are documented by openexchangerates.org. Additionally, this small PR showcases the approach that would be taken for adding additional errors.

Currently users are seeing a slightly confusing `TypeError` when their accounts are being restricted by openexchangerates.org. Here's a screenshot of the failing test instance:
<img width="1175" alt="image" src="https://user-images.githubusercontent.com/9240/223929659-86039f20-8432-4669-bfdb-d7f096621dfb.png">
