### PR TITLE
Update CI: drop Ruby 2.6, add Ruby 3.2 & head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   test:
+    name: "Ruby ${{ matrix.ruby }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -21,13 +22,13 @@ jobs:
           - head
           - jruby-9.4
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
       - name: Install dependencies
-        run: bundle install -j 3
+        run: bundle install -j $(getconf _NPROCESSORS_ONLN) --retry 3
       - name: Run tests
         run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', jruby-9.4]
+        ruby:
+          - 2.7
+          - 3.0
+          - 3.1
+          - 3.2
+          - head
+          - jruby-9.4
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby


### PR DESCRIPTION
* Ruby 2.6 is EOL since Mar 2022 (happy to roll this back if you think tests should still run against this)
* Ruby 3.2 was released Dec 2022
* Run against Ruby head so we don't need to constantly update the CI script
* minor improvement: CI now shows "Ruby xx" instead of "xx"
* minor: bundle install now uses whatever number or CPU cores are available

-- thanks for open sourcing this gem 🙇 