### PR TITLE
fix: preserve rates for currencies missing from API response

### DIFF
--- a/lib/money/bank/open_exchange_rates_bank.rb
+++ b/lib/money/bank/open_exchange_rates_bank.rb
@@ -187,15 +187,14 @@ class Money
       # @return [Array] Array of exchange rates
       def update_rates
         store.transaction do
-          clear_rates!
-          exchange_rates.each do |exchange_rate|
-            rate = exchange_rate.last
-            currency = exchange_rate.first
+          new_rates = exchange_rates
+          new_rates.each do |currency, rate|
             next unless Money::Currency.find(currency)
 
             set_rate(source, currency, rate)
             set_rate(currency, source, 1.0 / rate)
           end
+          clear_cross_rates_for(new_rates)
         end
       end
 
@@ -435,6 +434,20 @@ class Money
       # @return [Hash] All rates from store as Hash
       def clear_rates!
         store.each_rate do |iso_from, iso_to|
+          add_rate(iso_from, iso_to, nil)
+        end
+      end
+
+      # Clears cross-rates for currencies present in new_rates
+      # Cross-rates are calculated on next access via calc_pair_rate_using_base
+      # Direct rates (source -> X) are not cleared, just overwritten
+      #
+      # @param new_rates [Hash] Rates hash from API response
+      def clear_cross_rates_for(new_rates)
+        store.each_rate do |iso_from, iso_to|
+          next if iso_from == source || iso_to == source
+          next unless new_rates.key?(iso_from) || new_rates.key?(iso_to)
+
           add_rate(iso_from, iso_to, nil)
         end
       end

--- a/test/data/partial_latest.json
+++ b/test/data/partial_latest.json
@@ -1,0 +1,16 @@
+{
+  "disclaimer": "Exchange rates are provided for informational purposes only.",
+  "license": "Data sourced from various providers.",
+  "timestamp": 1414008100,
+  "base": "USD",
+  "rates": {
+    "AED": 3.67304,
+    "AUD": 1.139103,
+    "BBD": 2,
+    "CAD": 1.124161,
+    "CHF": 0.951922,
+    "GBP": 0.62292,
+    "JPY": 107.0718,
+    "USD": 1
+  }
+}

--- a/test/open_exchange_rates_bank_test.rb
+++ b/test/open_exchange_rates_bank_test.rb
@@ -533,5 +533,48 @@ describe Money::Bank::OpenExchangeRatesBank do
       end
     end
   end
+
+  describe 'missing currencies' do
+    let(:oer_partial_path) do
+      data_file('partial_latest.json')
+    end
+
+    before do
+      add_to_webmock(subject)
+      # see test/data/latest.json +52
+      @latest_usd_eur_rate = 0.79085
+      # see test/data/latest.json +33
+      @latest_usd_cad_rate = 1.124161
+      subject.update_rates
+    end
+
+    it 'should preserve direct rates' do
+      _(subject.get_rate('USD', 'EUR')).must_equal @latest_usd_eur_rate
+      subject.cache = nil
+      stub_request(:get, subject.source_url)
+        .to_return(status: 200, body: File.read(oer_partial_path))
+      subject.update_rates
+      _(subject.get_rate('USD', 'EUR')).must_equal @latest_usd_eur_rate
+    end
+
+    it 'should update rates for currencies in response' do
+      _(subject.get_rate('USD', 'CAD')).must_equal @latest_usd_cad_rate
+      subject.cache = nil
+      stub_request(:get, subject.source_url)
+        .to_return(status: 200, body: File.read(oer_partial_path))
+      subject.update_rates
+      _(subject.get_rate('USD', 'CAD')).must_equal @latest_usd_cad_rate
+    end
+
+    it 'should exchange with preserved rates' do
+      money = Money.new(100, 'USD')
+      _(subject.exchange_with(money, 'EUR')).must_equal Money.new(79, 'EUR')
+      subject.cache = nil
+      stub_request(:get, subject.source_url)
+        .to_return(status: 200, body: File.read(oer_partial_path))
+      subject.update_rates
+      _(subject.exchange_with(money, 'EUR')).must_equal Money.new(79, 'EUR')
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
During the https://status.openexchangerates.org/incidents/8fxplkpf93hy, approximately 35 currencies including BRL, CNY, PHP, and IDR were missing from API responses. The current update_rates implementation calls clear_rates! which sets all rates to nil before setting new rates from the API response. When the API returns partial data, missing currencies end up with nil rates, causing Money::Bank::UnknownRate errors on conversion.

  This PR changes update_rates to overwrite direct rates (USD→X, X→USD) instead of clearing them first, and only clears cross-rates (X→Y) for currencies present in the response. This ensures that currencies missing from a partial API response retain their previous rates while still allowing cross-rates to be recalculated when their base rates change. The approach aligns with the original design intent from PR #64.
